### PR TITLE
Добавлена обработка конструктора new Date(d), где d - дата.

### DIFF
--- a/rtz2fix.js
+++ b/rtz2fix.js
@@ -13,8 +13,13 @@ if ((new Date(2014, 0, 1)).getHours() != 0 || new Date(2015, 0, 7).getHours() !=
               length >= 4 ? new NativeDate(NativeDate.UTC(Y, M, D, h)) :
               length >= 3 ? new NativeDate(NativeDate.UTC(Y, M, D)) :
               length >= 2 ? new NativeDate(NativeDate.UTC(Y, M)) :
-              length >= 1 ? new NativeDate(Y) :
-          new NativeDate();
+              length >= 1 ? (
+				Y instanceof Date
+				 ? new NativeDate(NativeDate.UTC(Y.getYear(), Y.getMonth(), Y.getDate(), Y.getHours(), Y.getMinutes(), Y.getSeconds(), Y.getMilliseconds()))
+				 : new NativeDate(Y)
+			  )
+			  :
+			  new NativeDate();
       if (length == 0) {
         date = new NativeDate(+date - date.getTimezoneOffset() * 60000);
       }


### PR DESCRIPTION
Без этой обработки каждая операция new Date(d) сдвигала время на tz часов назад (по крайней мере, так было у нас в проекте). С этой обработкой проблема устранилась.
